### PR TITLE
Export volume metrics

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"log"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -50,6 +51,7 @@ var (
 
 	// flags
 	flagPort int
+	flagVolume bool
 )
 
 // collector holds data for a prometheus collector.
@@ -120,7 +122,8 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 		if cached {
 			c = " (cached)"
 		}
-		log.Printf("Retrieved %s (%s), price: %f%s\n", qq.Symbol, qq.ShortName, qq.RegularMarketPrice, c)
+		log.Printf("Retrieved %s (%s), price: %f, volume: %s%s\n",
+			qq.Symbol, qq.ShortName, qq.RegularMarketPrice, strconv.Itoa(qq.RegularMarketVolume), c)
 
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc("quotes_exporter_price", "Asset Price.", ls, nil),
@@ -128,5 +131,14 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 			qq.RegularMarketPrice,
 			lvs...,
 		)
+
+		if flagVolume {
+			ch <- prometheus.MustNewConstMetric(
+				prometheus.NewDesc("quotes_exporter_volume", "Asset Volume.", ls, nil),
+				prometheus.GaugeValue,
+				float64(qq.RegularMarketVolume),
+				lvs...,
+			)
+		}
 	}
 }

--- a/collector.go
+++ b/collector.go
@@ -17,7 +17,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"log"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
@@ -122,8 +121,8 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 		if cached {
 			c = " (cached)"
 		}
-		log.Printf("Retrieved %s (%s), price: %f, volume: %s%s\n",
-			qq.Symbol, qq.ShortName, qq.RegularMarketPrice, strconv.Itoa(qq.RegularMarketVolume), c)
+		log.Printf("Retrieved %s (%s), price: %f, volume: %d%s\n",
+			qq.Symbol, qq.ShortName, qq.RegularMarketPrice, qq.RegularMarketVolume, c)
 
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc("quotes_exporter_price", "Asset Price.", ls, nil),

--- a/collector.go
+++ b/collector.go
@@ -50,7 +50,6 @@ var (
 
 	// flags
 	flagPort int
-	flagVolume bool
 )
 
 // collector holds data for a prometheus collector.
@@ -131,13 +130,11 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 			lvs...,
 		)
 
-		if flagVolume {
-			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc("quotes_exporter_volume", "Asset Volume.", ls, nil),
-				prometheus.GaugeValue,
-				float64(qq.RegularMarketVolume),
-				lvs...,
-			)
-		}
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc("quotes_exporter_volume", "Asset Volume.", ls, nil),
+			prometheus.GaugeValue,
+			float64(qq.RegularMarketVolume),
+			lvs...,
+		)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -67,7 +67,6 @@ func help(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	flag.IntVar(&flagPort, "port", 9340, "Port to listen for HTTP requests.")
-	flag.BoolVar(&flagVolume, "quote.volume", false, "Exports volume.")
 	flag.Parse()
 
 	reg := prometheus.NewRegistry()

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ func help(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	flag.IntVar(&flagPort, "port", 9340, "Port to listen for HTTP requests.")
+	flag.BoolVar(&flagVolume, "quote.volume", false, "Exports volume.")
 	flag.Parse()
 
 	reg := prometheus.NewRegistry()


### PR DESCRIPTION
Hi @marcopaganini

This PR allows to export the volume.

- For further information, please refer to https://github.com/marcopaganini/quotes-exporter/issues/1.

## Summary

- Implement `--quote.volume` flag.

```
$ ./quotes-exporter --help
Usage of ./quotes-exporter:
  -port int
    	Port to listen for HTTP requests. (default 9340)
  -quote.volume
    	Exports volume.
```

- Returns `quotes_exporter_volume` when enabled `--quote.volume`.

```
& curl -sS 'http://localhost:9340/price?symbols=AMZN,GOOG,SNAP' | grep quotes_exporter_volume
# HELP quotes_exporter_volume Asset Volume.
# TYPE quotes_exporter_volume gauge
quotes_exporter_volume{name="Alphabet Inc.",symbol="GOOG"} 1.648353e+06
quotes_exporter_volume{name="Amazon.com, Inc.",symbol="AMZN"} 5.7799e+06
quotes_exporter_volume{name="Snap Inc.",symbol="SNAP"} 2.1831525e+07
```
